### PR TITLE
Changed testing to use automatic AWS Nitro document generation

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -14,7 +14,6 @@ package nitro_eclave_attestation_document
 import (
 	"crypto/x509"
 	"fmt"
-	"time"
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/veraison/go-cose"
@@ -36,17 +35,6 @@ type AttestationDocument struct {
 /// If authentication passes, return the generated AttestationDocument representing the fields
 /// from the provided CBOR data
 func AuthenticateDocument(data []byte, root_certificate x509.Certificate) (*AttestationDocument, error) {
-	return authenticateDocumentImpl(data, root_certificate, time.Now())
-}
-
-/// Same as AuthenticateDocument, but allows the caller to set an alternate "current time" to allow
-/// tests to use saved attestation document data without triggering certificate expiry errors.
-/// THIS FUNCTION SHOULD ONLY BE USED IN TESTING
-func AuthenticateDocumentTest(data []byte, root_certificate x509.Certificate, test_time time.Time) (*AttestationDocument, error) {
-	return authenticateDocumentImpl(data, root_certificate, test_time)
-}
-
-func authenticateDocumentImpl(data []byte, root_certificate x509.Certificate, current_time time.Time) (*AttestationDocument, error) {
 	// Following the steps here: https://docs.aws.amazon.com/enclaves/latest/user/verify-root.html
 	// Step 1. Decode the CBOR object and map it to a COSE_Sign1 structure
 	var msg cose.Sign1Message
@@ -85,7 +73,6 @@ func authenticateDocumentImpl(data []byte, root_certificate x509.Certificate, cu
 		KeyUsages:                 []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 		MaxConstraintComparisions: 0, // sic: This typo is correct per the documentation, it will not be fixed
 		// per this issue: https://github.com/golang/go/issues/27969
-		CurrentTime: current_time,
 	}
 	_, err = end_user_cert.Verify(cert_verify_options)
 	if err != nil {

--- a/lib_test.go
+++ b/lib_test.go
@@ -134,32 +134,36 @@ func generateCertsAndKeys() (*ecdsa.PrivateKey, []byte, *x509.Certificate, []byt
 	return endKey, endCertDer, caCert, caCertDer, nil
 }
 
+const NUM_PCRS = 16
+
+func generateRandomSlice(size int32) []byte {
+	result := make([]byte, size)
+	rand.Read(result)
+	return result
+}
+func generatePCRs() (map[int32][]byte, error) {
+	pcrs := make(map[int32][]byte)
+	for i := int32(0); i < NUM_PCRS; i++ {
+		pcrs[i] = generateRandomSlice(96)
+	}
+	return pcrs, nil
+}
+
 func Test_AuthenticateDocument_ok(t *testing.T) {
 	endKey, endCertDer, caCert, caCertDer, err := generateCertsAndKeys()
 	if err != nil {
 		t.Fatalf("generateCertsAndKeys failed:%v\n", err)
 	}
-	PCRs := map[int32][]byte{
-		0:  {34, 249, 225, 201, 73, 32, 141, 165, 94, 176, 27, 155, 159, 200, 143, 135, 69, 79, 119, 186, 19, 63, 13, 130, 50, 11, 80, 150, 33, 201, 36, 130, 21, 42, 153, 208, 161, 35, 53, 185, 113, 120, 192, 45, 111, 151, 125, 1},
-		1:  {188, 223, 5, 254, 252, 202, 168, 229, 91, 242, 200, 214, 222, 233, 231, 155, 191, 243, 30, 52, 191, 40, 169, 154, 161, 158, 107, 41, 195, 126, 232, 11, 33, 74, 65, 75, 118, 7, 35, 110, 223, 38, 252, 183, 134, 84, 230, 63},
-		2:  {0, 148, 62, 168, 89, 20, 15, 237, 116, 225, 2, 95, 228, 26, 237, 179, 135, 128, 234, 229, 101, 107, 63, 158, 249, 180, 176, 230, 17, 19, 80, 49, 85, 68, 219, 62, 252, 218, 5, 114, 81, 8, 247, 43, 42, 177, 65, 247},
-		3:  {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		4:  {69, 84, 4, 35, 57, 230, 161, 221, 250, 200, 157, 183, 218, 88, 35, 29, 86, 25, 7, 55, 41, 52, 67, 51, 175, 240, 85, 66, 154, 190, 236, 107, 0, 111, 129, 177, 157, 17, 118, 0, 27, 130, 145, 248, 133, 40, 49, 6},
-		5:  {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		6:  {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		7:  {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		8:  {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		9:  {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		10: {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		11: {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		12: {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		13: {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		14: {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		15: {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+	PCRs, err := generatePCRs()
+	if err != nil {
+		t.Fatalf("generatePCRs failed:%v", err)
 	}
-	userData := []byte{124, 55, 16, 128, 121, 179, 232, 163, 109, 138, 121, 112, 222, 29, 109, 79, 241, 70, 30, 14, 53, 217, 85, 124, 77, 120, 157, 245, 224, 87, 102, 32}
-	nonce := []byte{198, 120, 200, 97, 53, 222, 83, 157, 24, 58, 207, 245, 136, 134, 217, 141, 251, 152, 35, 4, 26, 249, 249, 52, 191, 144, 154, 192, 248, 217, 98, 69}
+	userData := generateRandomSlice(32)
+	nonce := generateRandomSlice(32)
 	messageCbor, err := generateDocument(PCRs, userData, nonce, endCertDer, caCertDer, endKey)
+	if err != nil {
+		t.Fatalf("generateDocument failed:%v\n", err)
+	}
 
 	// We now have a ?valid? COSE. Try to authenticate it
 	document, err := AuthenticateDocument(messageCbor[1:], *caCert)
@@ -174,10 +178,23 @@ func Test_AuthenticateDocument_ok(t *testing.T) {
 }
 
 func Test_AuthenticateDocument_bad_signature(t *testing.T) {
-	tokenBytes, err := os.ReadFile("test/aws_nitro_document_bad_sig.cbor")
-	require.NoError(t, err)
-
-	_, err = AuthenticateDocumentTest(tokenBytes, rootCert, testTime)
+	endKey, endCertDer, caCert, caCertDer, err := generateCertsAndKeys()
+	if err != nil {
+		t.Fatalf("generateCertsAndKeys failed:%v\n", err)
+	}
+	PCRs, err := generatePCRs()
+	if err != nil {
+		t.Fatalf("generatePCRs failed:%v\n", err)
+	}
+	userData := generateRandomSlice(32)
+	nonce := generateRandomSlice(32)
+	messageCbor, err := generateDocument(PCRs, userData, nonce, endCertDer, caCertDer, endKey)
+	if err != nil {
+		t.Fatalf("generateDocument failed:%v\n", err)
+	}
+	// modify the signature so it's not valid
+	messageCbor[len(messageCbor)-1] ^= messageCbor[len(messageCbor)-1]
+	_, err = AuthenticateDocument(messageCbor[1:], *caCert)
 	assert.EqualError(t, err, `AuthenticateDocument::Verify failed:verification error`)
 }
 

--- a/lib_test.go
+++ b/lib_test.go
@@ -12,13 +12,22 @@
 package nitro_eclave_attestation_document
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/pem"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"fmt"
+	"math/big"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/veraison/go-cose"
 )
 
 var testTime time.Time = time.Date(2022, 11, 9, 23, 0, 0, 0, time.UTC)
@@ -41,28 +50,127 @@ func init() {
 	rootCert = *cert
 }
 
+func generateDocument(PCRs map[int32][]byte, userData []byte, nonce []byte, signingCertDer []byte, caBundle []byte, signingKey *ecdsa.PrivateKey) ([]byte, error) {
+	document := AttestationDocument{
+		ModuleId:    "MyId",
+		TimeStamp:   uint64(time.Now().UnixMilli()),
+		Digest:      "SHA384",
+		PCRs:        PCRs,
+		Certificate: signingCertDer,
+		CABundle: [][]byte{
+			caBundle,
+		},
+		PublicKey: []byte{},
+		UserData:  userData,
+		Nonce:     nonce,
+	}
+	payload, err := cbor.Marshal(document)
+	if err != nil {
+		return nil, fmt.Errorf("cbor Marshal of document failed:%v", err)
+	}
+
+	msg := cose.NewSign1Message()
+	msg.Payload = payload
+	signer, err := cose.NewSigner(cose.AlgorithmES384, signingKey)
+	if err := msg.Sign(rand.Reader, []byte{}, signer); err != nil {
+		return nil, fmt.Errorf("Failed to sign:%v\n", err)
+	}
+
+	messageCbor, err := msg.MarshalCBOR()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to marshal CBOR:%v\n", err)
+	}
+	return messageCbor, nil
+}
+
+func generateCertsAndKeys() (*ecdsa.PrivateKey, []byte, *x509.Certificate, []byte, error) {
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("failed to generate CA key:%v", err)
+	}
+	caTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Acme Co"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Hour * 24 * 180),
+
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+
+	caCertDer, err := x509.CreateCertificate(rand.Reader, &caTemplate, &caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("Failed to generate CA Certificate:%v", err)
+	}
+	caCert, err := x509.ParseCertificate(caCertDer)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("Failed to convert CA Cert der to certificate:%v", err)
+	}
+
+	endKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("Failed to generate end key:%v", err)
+	}
+	endTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Acme Co"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Hour * 24 * 180),
+
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	endCertDer, err := x509.CreateCertificate(rand.Reader, &endTemplate, caCert, &endKey.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("Failed to generate end certificate:%v", err)
+	}
+	return endKey, endCertDer, caCert, caCertDer, nil
+}
+
 func Test_AuthenticateDocument_ok(t *testing.T) {
-	tokenBytes, err := os.ReadFile("test/aws_nitro_document.cbor")
-	require.NoError(t, err)
-	expectedPcr0 := [48]byte{
-		34, 249, 225, 201, 73, 32, 141, 165, 94, 176, 27, 155, 159, 200, 143, 135,
-		69, 79, 119, 186, 19, 63, 13, 130, 50, 11, 80, 150, 33, 201, 36, 130,
-		21, 42, 153, 208, 161, 35, 53, 185, 113, 120, 192, 45, 111, 151, 125, 1,
+	endKey, endCertDer, caCert, caCertDer, err := generateCertsAndKeys()
+	if err != nil {
+		t.Fatalf("generateCertsAndKeys failed:%v\n", err)
 	}
-	expectedNonce := [32]byte{
-		198, 120, 200, 97, 53, 222, 83, 157, 24, 58, 207, 245, 136, 134, 217, 141,
-		251, 152, 35, 4, 26, 249, 249, 52, 191, 144, 154, 192, 248, 217, 98, 69,
+	PCRs := map[int32][]byte{
+		0:  {34, 249, 225, 201, 73, 32, 141, 165, 94, 176, 27, 155, 159, 200, 143, 135, 69, 79, 119, 186, 19, 63, 13, 130, 50, 11, 80, 150, 33, 201, 36, 130, 21, 42, 153, 208, 161, 35, 53, 185, 113, 120, 192, 45, 111, 151, 125, 1},
+		1:  {188, 223, 5, 254, 252, 202, 168, 229, 91, 242, 200, 214, 222, 233, 231, 155, 191, 243, 30, 52, 191, 40, 169, 154, 161, 158, 107, 41, 195, 126, 232, 11, 33, 74, 65, 75, 118, 7, 35, 110, 223, 38, 252, 183, 134, 84, 230, 63},
+		2:  {0, 148, 62, 168, 89, 20, 15, 237, 116, 225, 2, 95, 228, 26, 237, 179, 135, 128, 234, 229, 101, 107, 63, 158, 249, 180, 176, 230, 17, 19, 80, 49, 85, 68, 219, 62, 252, 218, 5, 114, 81, 8, 247, 43, 42, 177, 65, 247},
+		3:  {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		4:  {69, 84, 4, 35, 57, 230, 161, 221, 250, 200, 157, 183, 218, 88, 35, 29, 86, 25, 7, 55, 41, 52, 67, 51, 175, 240, 85, 66, 154, 190, 236, 107, 0, 111, 129, 177, 157, 17, 118, 0, 27, 130, 145, 248, 133, 40, 49, 6},
+		5:  {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		6:  {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		7:  {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		8:  {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		9:  {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		10: {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		11: {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		12: {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		13: {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		14: {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		15: {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 	}
+	userData := []byte{124, 55, 16, 128, 121, 179, 232, 163, 109, 138, 121, 112, 222, 29, 109, 79, 241, 70, 30, 14, 53, 217, 85, 124, 77, 120, 157, 245, 224, 87, 102, 32}
+	nonce := []byte{198, 120, 200, 97, 53, 222, 83, 157, 24, 58, 207, 245, 136, 134, 217, 141, 251, 152, 35, 4, 26, 249, 249, 52, 191, 144, 154, 192, 248, 217, 98, 69}
+	messageCbor, err := generateDocument(PCRs, userData, nonce, endCertDer, caCertDer, endKey)
 
-	expectedUserData := [32]byte{
-		124, 55, 16, 128, 121, 179, 232, 163, 109, 138, 121, 112, 222, 29, 109, 79,
-		241, 70, 30, 14, 53, 217, 85, 124, 77, 120, 157, 245, 224, 87, 102, 32,
+	// We now have a ?valid? COSE. Try to authenticate it
+	document, err := AuthenticateDocument(messageCbor[1:], *caCert)
+	if err != nil {
+		t.Errorf("Failed to authenticate document:%v\n", err)
 	}
+	for i := int32(0); i < 16; i++ {
+		assert.Equal(t, PCRs[i], document.PCRs[i])
+	}
+	assert.Equal(t, userData, document.UserData)
 
-	doc, err := AuthenticateDocumentTest(tokenBytes, rootCert, testTime)
-	assert.Equal(t, expectedPcr0[:], doc.PCRs[0])
-	assert.Equal(t, expectedNonce[:], doc.Nonce)
-	assert.Equal(t, expectedUserData[:], doc.User_Data)
 }
 
 func Test_AuthenticateDocument_bad_signature(t *testing.T) {


### PR DESCRIPTION
Previously, tests used a specialized "test" path to enable use of old generated (and valid) AWS nitro attestation documents. This seemed dangerous.
Changed the tests to generate their own AWS nitro Attestation documents (signed by a randomly generated key instead of AWS's key). This allowed me to remove the specialized "test" path.