### PR TITLE
Added GO_DOC_SEED environment variable to make tests repeatable

### DIFF
--- a/lib_test.go
+++ b/lib_test.go
@@ -19,6 +19,9 @@ import (
 	"crypto/x509/pkix"
 	"fmt"
 	"math/big"
+	pseudoRand "math/rand"
+	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -28,7 +31,21 @@ import (
 )
 
 func init() {
+	envSeedValue := os.Getenv("GO_DOC_SEED")
 
+	var seed int64
+	var err error
+	if envSeedValue != "" {
+		seed, err = strconv.ParseInt(envSeedValue, 10, 64)
+		if err != nil {
+			panic("Error: Invalid input for seed\n")
+		}
+
+	} else {
+		seed = time.Now().UnixNano()
+	}
+	fmt.Printf("To repeat this test, set an environment variable GO_DOC_SEED to %v\n", seed)
+	pseudoRand.Seed(seed)
 }
 
 func generateDocument(PCRs map[int32][]byte, userData []byte, nonce []byte, signingCertDer []byte, caBundle []byte, signingKey *ecdsa.PrivateKey) ([]byte, error) {
@@ -136,7 +153,7 @@ const NUM_PCRS = 16
 
 func generateRandomSlice(size int32) []byte {
 	result := make([]byte, size)
-	rand.Read(result)
+	pseudoRand.Read(result)
 	return result
 }
 func generatePCRs() (map[int32][]byte, error) {


### PR DESCRIPTION
For some of the test randomness, we are now using math/rand instead of crypto/rand because math/rand allows the setting of a seed.

To enable repeatability of those random aspects of a test, it now prints out the seed value used. To re-use a given seed value, set and environment variable 'GO_DOC_SEED' to the seed value